### PR TITLE
Convert `degree_truth` to character early

### DIFF
--- a/vignettes/basic_usage.Rmd
+++ b/vignettes/basic_usage.Rmd
@@ -189,6 +189,7 @@ randomflip <- function(x, p=.2) ifelse(runif(length(x))<p, sample(unique(x)), x)
 set.seed(42)
 kinpairs_inferred <- kinpairs %>% 
   dplyr::mutate(degree_truth=kin2degree(k, max_degree=3)) %>% 
+  dplyr::mutate(degree_truth=as.character(degree_truth)) %>%
   dplyr::mutate(degree_truth=tidyr::replace_na(degree_truth, "unrelated")) %>% 
   dplyr::mutate(degree_inferred=randomflip(degree_truth))
 kinpairs_inferred


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize vctrs, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run the vignette, where you will get something like:

``` r
kinpairs_inferred <- kinpairs %>% 
  dplyr::mutate(degree_truth=kin2degree(k, max_degree=3)) %>% 
  dplyr::mutate(degree_truth=tidyr::replace_na(degree_truth, "unrelated")) %>% 
  dplyr::mutate(degree_inferred=randomflip(degree_truth))
#> Error: Problem with `mutate()` column `degree_truth`.
#> ℹ `degree_truth = tidyr::replace_na(degree_truth, "unrelated")`.
#> x Can't convert `replace` <character> to match type of `data` <integer>.
```

The problem boils down to the fact that you are trying to replace values in an _integer_ column, `degree_truth`, with a _character_ replacement value, `"unrelated"`. This is no longer allowed. To do this, you need to convert to a character column ahead of time, which is what this PR does.