### PR TITLE
Just call `read_table()`

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -50,7 +50,7 @@ read_fam <- function(file) {
 #'
 #' @export
 read_akt <- function(file) {
-  readr::read_table2(
+  readr::read_table(
     file,
     col_names=c("id1","id2","ibd0","ibd1","ibd2","k","nsnps"),
     col_types="ccddddi"
@@ -81,7 +81,7 @@ read_akt <- function(file) {
 #'
 #' @export
 read_ibis <- function(file){
-  readr::read_table2(file , col_names=c("id1", "id2", "k","ibd2","segment_count", "degree"), col_types="ccddii", skip = 1) %>%
+  readr::read_table(file , col_names=c("id1", "id2", "k","ibd2","segment_count", "degree"), col_types="ccddii", skip = 1) %>%
     dplyr::mutate(id1=gsub(":","_", id1)) %>%
     dplyr::mutate(id2=gsub(":","_", id2)) %>%
     arrange_ids(id1, id2)


### PR DESCRIPTION
The `read_table2()` function will be removed in the next release of readr. It has been deprecated for over 4 years, since readr v2.0.0 (2021-07-20). Since that time, it has just been aliased to `read_table()` anyway.

This is part of a bigger effort to advance a bunch of deprecation processes that started 4+ years ago: https://github.com/tidyverse/readr/issues/1600. I released readr v2.1.6 on 2025-11-14 and have no immediate plans for another release. I just wanted to advanced these deprecations right away, to give downstream dependencies plenty of time to adjust.

I am also sending an email to the maintainer listed in DESCRIPTION.